### PR TITLE
Implement Authorization for Company Creation using Keycloak

### DIFF
--- a/apps/authentication/contracts/jwt.ts
+++ b/apps/authentication/contracts/jwt.ts
@@ -10,7 +10,7 @@ export type JWTPayload = {
   'session_state': string
   'acr': string
   'allowed-origins': string[]
-  'realm_acces': {
+  'realm_access': {
     roles: string[]
   }
   'resource_access': { [key: string]: { roles: string[] } }
@@ -25,9 +25,8 @@ export type JWTPayload = {
   [key: string]: any
 }
 
-
 declare module '@japa/api-client' {
   interface ApiRequest {
-    loginAs(user: any): this
+    loginAs(user: any, realmRoles: string[]): this
   }
 }

--- a/apps/authentication/guards/jwt_guard.ts
+++ b/apps/authentication/guards/jwt_guard.ts
@@ -96,7 +96,7 @@ export class JwtGuard<UserProvider extends JwtUserProviderContract<unknown>>
     }
   }
 
-  async generate(user: UserProvider[typeof symbols.PROVIDER_REAL_USER]) {
+  async generate(user: UserProvider[typeof symbols.PROVIDER_REAL_USER], roles: string[]) {
     return {
       scope: 'profile email',
       sub: (user as any).oidcId,
@@ -104,13 +104,17 @@ export class JwtGuard<UserProvider extends JwtUserProviderContract<unknown>>
       preferred_username: 'nathael',
       given_name: 'Nathael',
       family_name: 'Sante',
+      realm_access: {
+        roles: [...roles],
+      },
     }
   }
 
   async authenticateAsClient(
-    user: UserProvider[typeof symbols.PROVIDER_REAL_USER]
+    user: UserProvider[typeof symbols.PROVIDER_REAL_USER],
+    realmRoles: string[]
   ): Promise<AuthClientResponse> {
-    const payload = await this.generate(user)
+    const payload = await this.generate(user, realmRoles)
 
     const token = jwt.sign(payload, 'secret', { expiresIn: '1h' })
 
@@ -130,5 +134,9 @@ export class JwtGuard<UserProvider extends JwtUserProviderContract<unknown>>
     }
 
     return this.user
+  }
+
+  async test(): Promise<this> {
+    return this
   }
 }

--- a/apps/companies/controllers/companies_controller.ts
+++ b/apps/companies/controllers/companies_controller.ts
@@ -23,10 +23,11 @@ export default class CompaniesController {
     return this.companyService.findAll(data)
   }
 
-  async create({ request, bouncer }: HttpContext) {
+  async create({ request, bouncer, response }: HttpContext) {
     await bouncer.with(CompanyPolicy).authorize('store')
     const data = await request.validateUsing(createCompanyValidator)
 
-    return this.companyService.create(data)
+    const company = await this.companyService.create(data)
+    return response.created(company)
   }
 }

--- a/apps/companies/controllers/companies_controller.ts
+++ b/apps/companies/controllers/companies_controller.ts
@@ -1,7 +1,8 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
 import CompanyService from '#apps/companies/services/company_service'
-import { createCompanyValidator, getComaniesValidator } from '../validators/company.js'
+import { createCompanyValidator, getComaniesValidator } from '#apps/companies/validators/company'
+import CompanyPolicy from '#apps/companies/policies/company_policy'
 
 @inject()
 export default class CompaniesController {
@@ -22,7 +23,8 @@ export default class CompaniesController {
     return this.companyService.findAll(data)
   }
 
-  async create({ request }: HttpContext) {
+  async create({ request, bouncer }: HttpContext) {
+    await bouncer.with(CompanyPolicy).authorize('store')
     const data = await request.validateUsing(createCompanyValidator)
 
     return this.companyService.create(data)

--- a/apps/companies/exceptions/company_exception.ts
+++ b/apps/companies/exceptions/company_exception.ts
@@ -1,0 +1,12 @@
+import { Exception } from '@adonisjs/core/exceptions'
+import { HttpContext } from '@adonisjs/core/http'
+
+export default class CompanyException extends Exception {
+  async handle(error: this, ctx: HttpContext) {
+    ctx.response.status(error.status).send({
+      message: error.message,
+      status: error.status,
+      code: error.code,
+    })
+  }
+}

--- a/apps/companies/policies.ts
+++ b/apps/companies/policies.ts
@@ -1,0 +1,3 @@
+export const companiesPolicies = {
+  CompanyPolicy: () => import('#apps/companies/policies/company_policy'),
+}

--- a/apps/companies/policies/company_policy.ts
+++ b/apps/companies/policies/company_policy.ts
@@ -1,0 +1,29 @@
+import { AuthorizationResponse, BasePolicy } from '@adonisjs/bouncer'
+import { JWTPayload } from '#apps/authentication/contracts/jwt'
+import { inject } from '@adonisjs/core'
+import RoleService from '#apps/shared/services/role_service'
+import CompanyException from '#apps/companies/exceptions/company_exception'
+import { Roles } from '#apps/shared/interfaces/roles'
+
+@inject()
+export default class CompanyPolicy extends BasePolicy {
+  constructor(private roleService: RoleService) {
+    super()
+  }
+
+  async after(_payload: JWTPayload, _action: string, response: AuthorizationResponse) {
+    if (!response.authorized) {
+      throw new CompanyException(response.message, {
+        status: response.status,
+        code: 'E_COMPANY_UNAUTHORIZED',
+      })
+    }
+  }
+
+  async store(payload: JWTPayload) {
+    if (this.roleService.verifyAccess(payload, Roles.COMPANY_CREATOR)) {
+      return AuthorizationResponse.allow()
+    }
+    return AuthorizationResponse.deny('You are not authorised to create a company', 403)
+  }
+}

--- a/apps/companies/services/company_service.ts
+++ b/apps/companies/services/company_service.ts
@@ -1,6 +1,7 @@
 import { Exception } from '@adonisjs/core/exceptions'
 import Company from '#apps/shared/models/company'
 import { CreateCompaniesSchema, GetCompaniesSchema } from '#apps/companies/validators/company'
+import logger from '@adonisjs/core/services/logger'
 
 export default class CompanyService {
   async findAll({ page = 1, limit = 10, nationalCode }: GetCompaniesSchema) {
@@ -12,7 +13,10 @@ export default class CompanyService {
   }
   async create(payload: CreateCompaniesSchema): Promise<Company> {
     try {
-      return Company.create(payload)
+      const company = await Company.create(payload)
+      logger.info(company.$attributes, 'Company created')
+
+      return company
     } catch (err) {
       throw new Exception('Failed to create company', {
         code: 'E_COMPANY_CREATE',

--- a/apps/shared/interfaces/roles.ts
+++ b/apps/shared/interfaces/roles.ts
@@ -1,0 +1,3 @@
+export enum Roles {
+  COMPANY_CREATOR = 'company_creator',
+}

--- a/apps/shared/policies/main.ts
+++ b/apps/shared/policies/main.ts
@@ -1,7 +1,9 @@
 import { patientPolicies } from '#apps/patient/policies'
 import { heartPolicies } from '#apps/heart/policies'
+import { companiesPolicies } from '#apps/companies/policies'
 
 export const policies = {
   ...patientPolicies,
   ...heartPolicies,
+  ...companiesPolicies,
 }

--- a/apps/shared/services/role_service.ts
+++ b/apps/shared/services/role_service.ts
@@ -1,0 +1,7 @@
+import { JWTPayload } from '#apps/authentication/contracts/jwt'
+
+export default class RoleService {
+  verifyAccess(payload: JWTPayload, role: string) {
+    return payload.realm_access.roles.includes(role)
+  }
+}

--- a/commands/documentation.ts
+++ b/commands/documentation.ts
@@ -1,0 +1,21 @@
+import { BaseCommand } from '@adonisjs/core/ace'
+import type { CommandOptions } from '@adonisjs/core/types/ace'
+import AutoSwagger from 'adonis-autoswagger'
+import swagger from '#config/swagger'
+
+export default class Documentation extends BaseCommand {
+  static commandName = 'docs:generate'
+  static description = ''
+
+  static options: CommandOptions = {
+    startApp: true,
+    allowUnknownFlags: false,
+    staysAlive: false,
+  }
+
+  async run() {
+    const Router = await this.app.container.make('router')
+    Router.commit()
+    await AutoSwagger.default.writeFile(Router.toJSON(), swagger)
+  }
+}

--- a/tests/functional/companies/create.spec.ts
+++ b/tests/functional/companies/create.spec.ts
@@ -3,7 +3,10 @@ import Professional from '#models/professional'
 import { Roles } from '#apps/shared/interfaces/roles'
 
 test.group('Companies create', () => {
-  test('example test', async ({ assert, client }) => {
+  test('should create a company and return a 201 status if the authenticated user has the necessary permission', async ({
+    assert,
+    client,
+  }) => {
     const professional = await Professional.firstOrFail()
 
     const response = await client
@@ -29,6 +32,36 @@ test.group('Companies create', () => {
       'phone',
       'nationalCode',
     ])
-    response.assertStatus(200)
+    response.assertStatus(201)
   }).tags(['companies'])
 })
+
+test('should return a 403 error if the authenticated user does not have the necessary permission', async ({
+  assert,
+  client,
+}) => {
+  const professional = await Professional.firstOrFail()
+
+  const response = await client.post('/v1/companies').loginAs(professional, []).json({
+    name: 'Company name',
+    address: 'Company address',
+    city: 'Company city',
+    country: 'Company country',
+    zipCode: 'Company zipCode',
+    phone: 'Company phone',
+    nationalCode: 'DZAD82D71D12',
+  })
+
+  response.assertStatus(403)
+  assert.properties(response.body(), ['code', 'message', 'status'])
+  assert.equal(response.body().code, 'E_COMPANY_UNAUTHORIZED')
+}).tags(['companies'])
+
+test('should return a 401 error if the user is not logged in', async ({ client, assert }) => {
+  const response = await client.post('/v1/companies')
+
+  response.assertStatus(401)
+
+  assert.properties(response.body(), ['code', 'message', 'status'])
+  assert.equal(response.body().code, 'E_AUTHENTICATION_UNAUTHORIZED')
+}).tags(['companies'])

--- a/tests/functional/companies/create.spec.ts
+++ b/tests/functional/companies/create.spec.ts
@@ -1,0 +1,34 @@
+import { test } from '@japa/runner'
+import Professional from '#models/professional'
+import { Roles } from '#apps/shared/interfaces/roles'
+
+test.group('Companies create', () => {
+  test('example test', async ({ assert, client }) => {
+    const professional = await Professional.firstOrFail()
+
+    const response = await client
+      .post('/v1/companies')
+      .loginAs(professional, [Roles.COMPANY_CREATOR])
+      .json({
+        name: 'Company name',
+        address: 'Company address',
+        city: 'Company city',
+        country: 'Company country',
+        zipCode: 'Company zipCode',
+        phone: 'Company phone',
+        nationalCode: 'DZAD82D71D12',
+      })
+
+    assert.properties(response.body(), [
+      'id',
+      'name',
+      'address',
+      'city',
+      'country',
+      'zipCode',
+      'phone',
+      'nationalCode',
+    ])
+    response.assertStatus(200)
+  }).tags(['companies'])
+})

--- a/tests/functional/heart/rates/create.spec.ts
+++ b/tests/functional/heart/rates/create.spec.ts
@@ -24,7 +24,7 @@ test.group('Heart Rates - Create', () => {
         startDate: '2024-05-05',
         value: 100,
       })
-      .loginAs(patient)
+      .loginAs(patient, [])
 
     response.assertStatus(201)
     assert.properties(response.body(), [
@@ -51,7 +51,7 @@ test.group('Heart Rates - Create', () => {
         startDate: '2024-05-05',
         value: 100,
       })
-      .loginAs(patient)
+      .loginAs(patient, [])
 
     response.assertStatus(403)
     assert.properties(response.body(), ['message', 'status', 'code'])

--- a/tests/functional/heart/rates/list.spec.ts
+++ b/tests/functional/heart/rates/list.spec.ts
@@ -7,7 +7,7 @@ test.group('Heart Rates - List', () => {
     client,
   }) => {
     const professional = await Professional.firstOrFail()
-    const response = await client.get('/v1/heart/rates/000000').loginAs(professional)
+    const response = await client.get('/v1/heart/rates/000000').loginAs(professional, [])
 
     response.assertStatus(404)
     assert.properties(response.body(), ['code', 'message', 'status'])

--- a/tests/functional/patients/list.spec.ts
+++ b/tests/functional/patients/list.spec.ts
@@ -9,7 +9,7 @@ test.group('Patients - List', () => {
   }) => {
     const patient = await Patient.firstOrFail()
 
-    const response = await client.get('/v1/patients').loginAs(patient)
+    const response = await client.get('/v1/patients').loginAs(patient, [])
 
     response.assertStatus(403)
 
@@ -23,7 +23,7 @@ test.group('Patients - List', () => {
   }) => {
     const professional = await Professional.firstOrFail()
 
-    const response = await client.get('/v1/patients').loginAs(professional)
+    const response = await client.get('/v1/patients').loginAs(professional, [])
     response.assertStatus(200)
     assert.properties(response.body(), ['data', 'meta'])
   }).tags(['patients'])


### PR DESCRIPTION
This pull request implements authorization checks for the creation of companies within our application using Keycloak. The main goal is to ensure that only users with the necessary permissions can create new company records. The implementation includes the following.

1. Keycloak Configuration
    - A new permission named `create_company` has been defined in Keycloak.
    - This permission has been assigned to relevant roles such as `admin` and `superuser`
2. Policy Creation and Application
    - A policy has been created to ensure that the user has the necessary authorization to perform the action of creating a company.
    - This policy has been applied to the company creation endpoint in our application.
3. Testing
    - Tests have been written to verify that unauthorized users receive a `403 Forbidden` response when attempting to create a company.
    - Additional tests ensure that authorized users with the appropriate permissions can successfully create a company and receive a `201 Created` response.
    - Tests also check for the correct error handling, ensuring that users without a valid JWT receive a `401 Unauthorized` response.
