### PR TITLE
Addition of tests and reinforcement of authorisations for companies

### DIFF
--- a/apps/companies/controllers/companies_controller.ts
+++ b/apps/companies/controllers/companies_controller.ts
@@ -17,10 +17,16 @@ export default class CompaniesController {
    * @responseHeader 200 - @use(paginated)
    * @responseHeader 200 - X-pages - A description of the header - @example(test)
    */
-  async index({ request }: HttpContext) {
+  async index({ request, bouncer }: HttpContext) {
+    await bouncer.with(CompanyPolicy).authorize('view')
     const data = await request.validateUsing(getComaniesValidator)
 
     return this.companyService.findAll(data)
+  }
+
+  async show({ params, bouncer }: HttpContext) {
+    await bouncer.with(CompanyPolicy).allows('show' as never, params.id)
+    return this.companyService.findById(params.id)
   }
 
   async create({ request, bouncer, response }: HttpContext) {

--- a/apps/companies/policies/company_policy.ts
+++ b/apps/companies/policies/company_policy.ts
@@ -4,10 +4,14 @@ import { inject } from '@adonisjs/core'
 import RoleService from '#apps/shared/services/role_service'
 import CompanyException from '#apps/companies/exceptions/company_exception'
 import { Roles } from '#apps/shared/interfaces/roles'
+import ProfessionalService from '#apps/professional/services/professional_service'
 
 @inject()
 export default class CompanyPolicy extends BasePolicy {
-  constructor(private roleService: RoleService) {
+  constructor(
+    private roleService: RoleService,
+    private professionalService: ProfessionalService
+  ) {
     super()
   }
 
@@ -17,6 +21,27 @@ export default class CompanyPolicy extends BasePolicy {
         status: response.status,
         code: 'E_COMPANY_UNAUTHORIZED',
       })
+    }
+  }
+
+  async view(payload: JWTPayload) {
+    if (this.roleService.verifyAccess(payload, Roles.COMPANY_VIEWER)) {
+      return AuthorizationResponse.allow()
+    }
+
+    return AuthorizationResponse.deny('You are not authorized to view companies', 403)
+  }
+
+  async show(payload: JWTPayload, companyId: string) {
+    try {
+      const professional = await this.professionalService.findByOidcId(payload.sub)
+      if (!professional || professional.companyId !== companyId) {
+        return AuthorizationResponse.deny('You are not authorized to view this company', 403)
+      }
+
+      return AuthorizationResponse.allow()
+    } catch (error) {
+      return AuthorizationResponse.deny('You are not authorized to view this company', 403)
     }
   }
 

--- a/apps/companies/routes.ts
+++ b/apps/companies/routes.ts
@@ -8,6 +8,7 @@ router
     router
       .group(() => {
         router.get('/', [CompaniesController, 'index'])
+        router.get('/:id', [CompaniesController, 'show'])
         router.post('/', [CompaniesController, 'create'])
       })
       .prefix('/companies')

--- a/apps/companies/services/company_service.ts
+++ b/apps/companies/services/company_service.ts
@@ -11,6 +11,11 @@ export default class CompanyService {
       })
       .paginate(page, limit)
   }
+
+  async findById(id: string) {
+    return Company.query().where('id', id).first()
+  }
+
   async create(payload: CreateCompaniesSchema): Promise<Company> {
     try {
       const company = await Company.create(payload)

--- a/apps/shared/interfaces/roles.ts
+++ b/apps/shared/interfaces/roles.ts
@@ -1,3 +1,4 @@
 export enum Roles {
   COMPANY_CREATOR = 'company_creator',
+  COMPANY_VIEWER = 'view_company',
 }

--- a/apps/shared/models/company.ts
+++ b/apps/shared/models/company.ts
@@ -2,7 +2,7 @@ import Professional from '#models/professional'
 import { BaseModel, beforeCreate, column, hasMany } from '@adonisjs/lucid/orm'
 import type { HasMany } from '@adonisjs/lucid/types/relations'
 import { DateTime } from 'luxon'
-import { randomUUID } from 'node:crypto'
+import { generateSnowflake } from '#apps/shared/services/snowflake_service'
 
 export default class Company extends BaseModel {
   @column({ isPrimary: true })
@@ -43,6 +43,8 @@ export default class Company extends BaseModel {
 
   @beforeCreate()
   static async generateUuid(model: Company) {
-    model.id = randomUUID()
+    if (!model.id) {
+      model.id = generateSnowflake()
+    }
   }
 }

--- a/apps/shared/models/professional.ts
+++ b/apps/shared/models/professional.ts
@@ -34,6 +34,8 @@ export default class Professional extends BaseModel {
 
   @beforeCreate()
   static async generateUuid(model: Professional) {
-    model.id = generateSnowflake()
+    if (!model.id) {
+      model.id = generateSnowflake()
+    }
   }
 }

--- a/database/seeders/basic_company_and_patient_seeder.ts
+++ b/database/seeders/basic_company_and_patient_seeder.ts
@@ -6,11 +6,12 @@ import { DateTime } from 'luxon'
 
 export default class extends BaseSeeder {
   async run() {
-    const company = await Company.firstOrCreate(
+    await Company.firstOrCreate(
       {
         nationalCode: '340785161',
       },
       {
+        id: '5836049162517872642997799',
         address: '371 Avenue Du Doyen Gaston Giraud',
         city: 'Montpellier',
         country: 'France',
@@ -27,6 +28,7 @@ export default class extends BaseSeeder {
         nationalCode: '340796663',
       },
       {
+        id: '9336049162517872642997616',
         address: '371 Avenue Du Doyen Gaston Giraud',
         city: 'Montpellier',
         country: 'France',
@@ -54,7 +56,7 @@ export default class extends BaseSeeder {
       },
       {
         name: 'Nathalos',
-        companyId: company.id,
+        companyId: '5836049162517872642997799',
         licenceNumber: '3723719331',
         oidcId: '77a1e767-a964-4df4-bda8-28529c243441',
         speciality: 'diabetic',

--- a/tests/functional/companies/list.spec.ts
+++ b/tests/functional/companies/list.spec.ts
@@ -1,0 +1,29 @@
+import { test } from '@japa/runner'
+import Professional from '#models/professional'
+
+test.group('Companies list', () => {
+  test('should return 403 for unauthorized user ', async ({ assert, client }) => {
+    const professional = await Professional.firstOrFail()
+    const response = await client.get('/v1/companies').loginAs(professional, [])
+
+    response.assertStatus(403)
+    assert.properties(response.body(), ['code', 'message', 'status'])
+    assert.equal(response.body().code, 'E_COMPANY_UNAUTHORIZED')
+  }).tags(['companies'])
+
+  test('should return a 401 error if the user is not logged in', async ({ client, assert }) => {
+    const response = await client.get('/v1/companies')
+    response.assertStatus(401)
+
+    assert.properties(response.body(), ['code', 'message', 'status'])
+    assert.equal(response.body().code, 'E_AUTHENTICATION_UNAUTHORIZED')
+  }).tags(['companies'])
+
+  test('should return 200 for authorized user', async ({ client, assert }) => {
+    const professional = await Professional.firstOrFail()
+    const response = await client.get('/v1/companies').loginAs(professional, ['view_company'])
+
+    response.assertStatus(200)
+    assert.properties(response.body(), ['meta', 'data'])
+  }).tags(['companies'])
+})

--- a/tests/functional/companies/show.spec.ts
+++ b/tests/functional/companies/show.spec.ts
@@ -1,0 +1,51 @@
+import { test } from '@japa/runner'
+import Patient from '#models/patient'
+import Professional from '#models/professional'
+
+test.group('Companies show', () => {
+  test('should return 401 when not authenticated', async ({ client, assert }) => {
+    const response = await client.get('/v1/companies/5836049162517872642997799')
+
+    response.assertStatus(401)
+    assert.properties(response.body(), ['message', 'status', 'code'])
+    assert.equal(response.body().code, 'E_AUTHENTICATION_UNAUTHORIZED')
+  }).tags(['companies'])
+
+  test('should return 403 for patient', async ({ assert, client }) => {
+    const user = await Patient.findByOrFail('oidc_id', '9f6ca596-908e-4a53-a977-c2065cf98e44')
+    const response = await client.get('/v1/companies/5836049162517872642997799').loginAs(user, [])
+
+    response.assertStatus(403)
+    assert.properties(response.body(), ['message', 'status', 'code'])
+    assert.equal(response.body().code, 'E_COMPANY_UNAUTHORIZED')
+  }).tags(['companies'])
+
+  test('should return 403 for unauthorized professional', async ({ client, assert }) => {
+    const user = await Professional.findByOrFail('oidc_id', '77a1e767-a964-4df4-bda8-28529c243441')
+
+    const response = await client.get('/v1/companies/9336049162517872642997616').loginAs(user, [])
+
+    response.assertStatus(403)
+    assert.properties(response.body(), ['message', 'status', 'code'])
+    assert.equal(response.body().code, 'E_COMPANY_UNAUTHORIZED')
+  }).tags(['companies'])
+
+  test('should return 200 for authorized professional', async ({ client, assert }) => {
+    const user = await Professional.findByOrFail('oidc_id', '77a1e767-a964-4df4-bda8-28529c243441')
+
+    const response = await client.get('/v1/companies/5836049162517872642997799').loginAs(user, [])
+
+    response.assertStatus(200)
+    assert.include(response.body(), {
+      id: '5836049162517872642997799',
+      name: 'Centre Hospitalier Universitaire Lapeyronie',
+      address: '371 Avenue Du Doyen Gaston Giraud',
+      city: 'Montpellier',
+      country: 'France',
+      zipCode: '34295',
+      phone: '0467336733',
+      email: 'contact@lapeyronie.fr',
+      nationalCode: '340785161',
+    })
+  }).tags(['companies'])
+})


### PR DESCRIPTION
This PullRequest adds functional tests for the `companies` module. The tests cover the following cases:

- List of companies
- Information about a company

There are three ways of recovering companies:
- **200**: If the logged-in user has the necessary rights.
- **401**: If the user is not logged in.
- **403**: If the logged-in user does not have the necessary rights.

In terms of recovering a company, the cases are as follows:
- **401** If the user is not logged in
- **403** If the user is not a professional or if the professional is not present in the company.
- **200** If the user is present in the company and is a professional.

## Integration of policies in the controller
Bouncers have been added to the various methods in order to protect access to resources with an authorisation system.